### PR TITLE
Link Rui RP3D's name in the Thanks section to their GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ patience — testing on real hardware, catching what a compiler cannot, and tell
 us plainly when something did not work.
 
 - **[OpenMaker](https://github.com/BenGlut)** (BenGlut)
-- **Rui RP3D**
+- **[Rui RP3D](https://github.com/RP3D-S)**
 - **[Ptitlouis6012](https://github.com/Ptitlouis6012)**
 
 And thank you to everyone supporting the project through Buy Me a Coffee. You know


### PR DESCRIPTION
## What does this change?

Links Rui RP3D's name in the README's Thanks section to their GitHub profile (https://github.com/RP3D-S), matching how the other two names in that list are already linked.

## Why?

The name was plain text with no link, while OpenMaker and Ptitlouis6012 right above/below it both link to their GitHub profiles. This was pointed out with the correct profile URL.

## How was it tested?

Docs only — no firmware code touched. Visual check: the link renders correctly (blue, same style as the other two names) and points to https://github.com/RP3D-S.

## Checklist

- [x] `bash scripts/check-codemap.sh` passes — N/A, `.ino` not touched
- [x] `bash scripts/check-i18n.sh` passes — N/A, no i18n files touched
- [x] `bash scripts/update_toc.sh` run — N/A, no `// §N —` banner touched
- [x] `WORKLOG.md` updated
- [x] Comments I touched are still true of the code around them
- [x] Smallest diff that does the job — no unrelated reformatting