### PR TITLE
Move speaker and battery rows above the fasteners in the BOM tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ the IDE has no equivalent for.
 | 2 | PN532 **V3** NFC module — pin header **and** mode switch required | [buy](https://link.amazon/B0iTXrhjd) |
 | 1 | 5 kg load cell + HX711 | [buy](https://link.amazon/B09LOUuI1) |
 | 1 | USB-C 4-pin cable + connector | [cable](https://link.amazon/B0aoW8qQx) · [connector](https://link.amazon/B0aiEyjLx) |
-| — | Dupont wires, M3 self-tapping screws | [wires](https://link.amazon/B0bl6jvMs) · [screws](https://link.amazon/B0ekzxx1E) |
-| — | 2× M4×30 and 2× M5×30 (load cell), 4× M2×6 (display) | — |
 | 1 | Small speaker | ships with the ESP32-S3 board |
 | 1 | Li-ion battery | [optional](https://link.amazon/B0etKlE1i) — the scale runs on USB |
+| — | Dupont wires, M3 self-tapping screws | [wires](https://link.amazon/B0bl6jvMs) · [screws](https://link.amazon/B0ekzxx1E) |
+| — | 2× M4×30 and 2× M5×30 (load cell), 4× M2×6 (display) | — |
 | — | Enclosure — printable 3MF, Bambu Studio project | [download](https://github.com/TigerTag-Project/Tiger-Scale-V3/releases/download/enclosure/TigerScale-V3-enclosure.3mf) |
 
 Full costed list with every link: **[docs/HARDWARE.md](docs/HARDWARE.md#bill-of-materials)**

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -59,9 +59,9 @@ nothing extra and helps keep the TigerTag cloud free.
 | 1 | **5 kg load cell + HX711 amplifier** | [Amazon](https://link.amazon/B09LOUuI1) |
 | 1 | **USB-C 4-pin cable** | [Amazon](https://link.amazon/B0aoW8qQx) |
 | 1 | **USB-C connector / breakout** | [Amazon](https://link.amazon/B0aiEyjLx) |
-| — | **Dupont wires** | [Amazon](https://link.amazon/B0bl6jvMs) |
 | 1 | Small speaker for the board's SPK connector — supplied with the board, gives the beep on tag detect | — |
 | 1 | Li-ion battery — optional; charging and level reporting are handled by the on-board AXP2101 | [Amazon](https://link.amazon/B0etKlE1i) |
+| — | **Dupont wires** | [Amazon](https://link.amazon/B0bl6jvMs) |
 
 > [!WARNING]
 > **The sealed USB-C-only PN532 dongles will not work.** They have no pin header, and


### PR DESCRIPTION
## What does this change?

Moves the "Small speaker" and "Li-ion battery" rows above the fasteners (Dupont wires, screws) in the bill-of-materials tables, in both README.md and docs/HARDWARE.md — right after the USB-C connector.

## Why?

Both tables otherwise group by kind (board, readers, load cell, cabling, then fasteners), but the speaker and battery — both electronics that ship with or plug into the board — were listed after the fasteners instead of with the rest of the electronics.

## How was it tested?

Docs only — no firmware code touched. Visual check: read the rendered diff for both tables, row order and content otherwise unchanged.

## Checklist

- [x] `bash scripts/check-codemap.sh` passes — N/A, `.ino` not touched
- [x] `bash scripts/check-i18n.sh` passes — N/A, no i18n files touched
- [x] `bash scripts/update_toc.sh` run — N/A, no `// §N —` banner touched
- [x] `WORKLOG.md` updated — N/A, WORKLOG.md is maintainer-scoped, not touched by this fork PR
- [x] Comments I touched are still true of the code around them
- [x] Smallest diff that does the job — no unrelated reformatting