### PR TITLE
Move the driver guide into docs/ and point Windows at Espressif's download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Full terms: **[TRADEMARK.md](TRADEMARK.md)**.
 | **[docs/INSTALLATION.md](docs/INSTALLATION.md)** | Building, flashing, first boot |
 | **[docs/HARDWARE.md](docs/HARDWARE.md)** | Pinout, buses, wiring per transport |
 | **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** | When something doesn't work |
+| **[docs/SERIAL-PORT.md](docs/SERIAL-PORT.md)** | No COM port when flashing: drivers per OS |
 | **[docs/CLOUD.md](docs/CLOUD.md)** | What's sent, what's stored, how to wipe it |
 | **[docs/TELEMETRY.md](docs/TELEMETRY.md)** | Every reported field, for anything reading a scale |
 | **[docs/FIRMWARE.md](docs/FIRMWARE.md)** | Internals, for contributors |

--- a/docs/SERIAL-PORT.md
+++ b/docs/SERIAL-PORT.md
@@ -1,6 +1,6 @@
-# Getting the COM port to show up to flash the Tiger Scale v3
+# Getting the COM port to show up to flash the TigerScale V3
 
-The Tiger Scale v3 uses an **ESP32-S3** chip. To flash the firmware, your computer needs to see the board as a **COM port / serial port**.
+The TigerScale V3 uses an **ESP32-S3** chip. To flash the firmware, your computer needs to see the board as a **COM port / serial port**.
 
 On most recent computers this port shows up **on its own** when you plug the board in.
 If no port appears in the flasher, a small driver is missing: follow the section for your system below.
@@ -21,20 +21,26 @@ If it doesn't appear: swap the USB cable and try again.
 
 ## Windows — install the driver (if no COM port appears)
 
-If the flasher shows no port, install the Espressif driver. **Just one command to copy and paste.**
+If the flasher shows no port, the Espressif USB driver is missing. Install it
+from Espressif's own tooling page:
 
-1. Click the **Start** menu.
-2. Type `powershell`.
-3. **Right-click** "Windows PowerShell" → **"Run as administrator"**.
-4. Copy and paste the line below, then press **Enter**:
+**[dl.espressif.com/dl/idf-installer](https://dl.espressif.com/dl/idf-installer/)**
 
-   ```powershell
-   Invoke-WebRequest 'https://dl.espressif.com/dl/idf-env/idf-env.exe' -OutFile .\idf-env.exe; .\idf-env.exe driver install --espressif
-   ```
+Download `idf-env` from there, then run it as administrator with:
 
-5. Wait for it to finish (a few seconds).
-6. **Unplug and plug the board back in.**
-7. Reopen the flasher: the port (e.g. `USB JTAG/serial debug unit (COM3)`) should now appear.
+```powershell
+.\idf-env.exe driver install --espressif
+```
+
+Then:
+
+1. Wait for it to finish (a few seconds).
+2. **Unplug and plug the board back in.**
+3. Reopen the flasher: the port (e.g. `USB JTAG/serial debug unit (COM3)`) should now appear.
+
+> Downloading the tool yourself, rather than pasting a one-line command that
+> fetches and runs an executable with administrator rights, means you can see
+> what you are about to run and where it came from. It is one extra click.
 
 ✓ Select this port and start the flash.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -121,6 +121,12 @@ pio device monitor
 The `esp32_exception_decoder` filter is enabled in `platformio.ini`, so
 backtraces come out with function names attached.
 
+## The flasher shows no COM port at all
+
+The board never appears in the list, so there is nothing to select. That is a
+missing driver or a charge-only USB cable, not a fault in the scale — per-OS
+instructions are in [SERIAL-PORT.md](SERIAL-PORT.md).
+
 ## Nothing on the serial console
 
 `ARDUINO_USB_CDC_ON_BOOT=1` must be set — it is, in every env — otherwise

--- a/web-installer/i18n.js
+++ b/web-installer/i18n.js
@@ -52,7 +52,7 @@ en: {
   erase_b: "It erases everything on it, including any saved WiFi password, and writes the bootloader, the partition table, the firmware and the web interface. That is what you want on a board you have just built.",
   erase_u_html: 'To update a scale that already works, use <b>Settings &rarr; Update</b> on its own screen. That keeps your settings.',
   noport_t: "No COM port detected?",
-  noport_b_html: 'A driver may be missing for your system. Follow the <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">driver installation guide</a>.',
+  noport_b_html: 'A driver may be missing for your system. Follow the <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">driver installation guide</a>.',
 
   s3_title: "Once it is done",
   a1_html: "The scale starts up and asks for <b>WiFi</b>. Choose your network on the touchscreen.",
@@ -122,7 +122,7 @@ fr: {
   erase_b: "Elle efface tout, y compris un mot de passe WiFi enregistré, et écrit le bootloader, la table de partitions, le micrologiciel et l'interface web. C'est bien ce que l'on veut sur une carte qu'on vient de monter.",
   erase_u_html: "Pour mettre à jour une balance qui fonctionne déjà, utilisez <b>Réglages &rarr; Mise à jour</b> sur son écran. Vos réglages sont conservés.",
   noport_t: "Aucun port COM détecté ?",
-  noport_b_html: 'Il manque peut-être un pilote pour votre système. Suivez le <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">guide d\'installation du pilote</a>.',
+  noport_b_html: 'Il manque peut-être un pilote pour votre système. Suivez le <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">guide d\'installation du pilote</a>.',
 
   s3_title: "Une fois terminé",
   a1_html: "La balance démarre et demande le <b>WiFi</b>. Choisissez votre réseau sur l'écran tactile.",
@@ -192,7 +192,7 @@ de: {
   erase_b: "Sie löscht alles, auch ein gespeichertes WLAN-Passwort, und schreibt Bootloader, Partitionstabelle, Firmware und Weboberfläche. Genau das will man auf einer frisch aufgebauten Platine.",
   erase_u_html: 'Um eine bereits laufende Waage zu aktualisieren, nutzen Sie <b>Einstellungen &rarr; Update</b> auf ihrem Bildschirm. Ihre Einstellungen bleiben erhalten.',
   noport_t: "Kein COM-Port erkannt?",
-  noport_b_html: 'Möglicherweise fehlt ein Treiber für Ihr System. Folgen Sie der <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">Anleitung zur Treiberinstallation</a>.',
+  noport_b_html: 'Möglicherweise fehlt ein Treiber für Ihr System. Folgen Sie der <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">Anleitung zur Treiberinstallation</a>.',
 
   s3_title: "Wenn es fertig ist",
   a1_html: "Die Waage startet und fragt nach <b>WLAN</b>. Wählen Sie Ihr Netz auf dem Touchscreen.",
@@ -262,7 +262,7 @@ es: {
   erase_b: "Borra todo, incluida cualquier contraseña WiFi guardada, y escribe el bootloader, la tabla de particiones, el firmware y la interfaz web. Es justo lo que se quiere en una placa recién montada.",
   erase_u_html: 'Para actualizar una báscula que ya funciona, use <b>Ajustes &rarr; Actualizar</b> en su pantalla. Conserva sus ajustes.',
   noport_t: "¿No se detecta ningún puerto COM?",
-  noport_b_html: 'Puede que falte un controlador para su sistema. Siga la <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">guía de instalación del controlador</a>.',
+  noport_b_html: 'Puede que falte un controlador para su sistema. Siga la <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">guía de instalación del controlador</a>.',
 
   s3_title: "Cuando termine",
   a1_html: "La báscula arranca y pide el <b>WiFi</b>. Elija su red en la pantalla táctil.",
@@ -332,7 +332,7 @@ it: {
   erase_b: "Cancella tutto, compresa un'eventuale password WiFi salvata, e scrive bootloader, tabella delle partizioni, firmware e interfaccia web. È esattamente ciò che serve su una scheda appena montata.",
   erase_u_html: 'Per aggiornare una bilancia già funzionante usa <b>Impostazioni &rarr; Aggiornamento</b> sul suo schermo. Le impostazioni restano.',
   noport_t: "Nessuna porta COM rilevata?",
-  noport_b_html: "Potrebbe mancare un driver per il tuo sistema. Segui la <a href=\"https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md\">guida all'installazione del driver</a>.",
+  noport_b_html: "Potrebbe mancare un driver per il tuo sistema. Segui la <a href=\"https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md\">guida all'installazione del driver</a>.",
 
   s3_title: "Quando ha finito",
   a1_html: "La bilancia si avvia e chiede il <b>WiFi</b>. Scegli la tua rete sul touchscreen.",
@@ -402,7 +402,7 @@ pl: {
   erase_b: "Kasuje wszystko, łącznie z zapisanym hasłem WiFi, i zapisuje bootloader, tablicę partycji, firmware oraz interfejs webowy. Dokładnie tego chcesz na świeżo zmontowanej płytce.",
   erase_u_html: 'Aby zaktualizować działającą już wagę, użyj <b>Ustawienia &rarr; Aktualizacja</b> na jej ekranie. Ustawienia zostaną zachowane.',
   noport_t: "Nie wykryto portu COM?",
-  noport_b_html: 'Może brakować sterownika dla Twojego systemu. Skorzystaj z <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">przewodnika instalacji sterownika</a>.',
+  noport_b_html: 'Może brakować sterownika dla Twojego systemu. Skorzystaj z <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">przewodnika instalacji sterownika</a>.',
 
   s3_title: "Gdy się skończy",
   a1_html: "Waga uruchamia się i pyta o <b>WiFi</b>. Wybierz swoją sieć na ekranie dotykowym.",
@@ -472,7 +472,7 @@ pt: {
   erase_b: "Ela apaga tudo, inclusive qualquer senha de WiFi salva, e grava o bootloader, a tabela de partições, o firmware e a interface web. É exatamente o que se quer numa placa recém-montada.",
   erase_u_html: 'Para atualizar uma balança que já funciona, use <b>Configurações &rarr; Atualização</b> na tela dela. Suas configurações são mantidas.',
   noport_t: "Nenhuma porta COM detectada?",
-  noport_b_html: 'Pode faltar um driver para o seu sistema. Siga o <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">guia de instalação do driver</a>.',
+  noport_b_html: 'Pode faltar um driver para o seu sistema. Siga o <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">guia de instalação do driver</a>.',
 
   s3_title: "Quando terminar",
   a1_html: "A balança liga e pede o <b>WiFi</b>. Escolha sua rede na tela sensível ao toque.",
@@ -542,7 +542,7 @@ pt: {
   erase_b: "Apaga tudo, incluindo qualquer palavra-passe de WiFi guardada, e grava o bootloader, a tabela de partições, o firmware e a interface web. É exactamente o que se quer numa placa acabada de montar.",
   erase_u_html: 'Para actualizar uma balança que já funciona, use <b>Definições &rarr; Actualização</b> no ecrã dela. As suas definições mantêm-se.',
   noport_t: "Nenhuma porta COM detetada?",
-  noport_b_html: 'Pode faltar um controlador para o seu sistema. Siga o <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">guia de instalação do controlador</a>.',
+  noport_b_html: 'Pode faltar um controlador para o seu sistema. Siga o <a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">guia de instalação do controlador</a>.',
 
   s3_title: "Quando terminar",
   a1_html: "A balança arranca e pede o <b>WiFi</b>. Escolha a sua rede no ecrã táctil.",
@@ -612,7 +612,7 @@ zh: {
   erase_b: "它会擦掉板上所有内容，包括已保存的 WiFi 密码，然后写入引导程序、分区表、固件和网页界面。对刚装好的板子来说，这正是你要的。",
   erase_u_html: '要更新已经在用的秤，请在它自己的屏幕上用<b>设置 &rarr; 更新</b>。设置会保留。',
   noport_t: "没有检测到 COM 端口？",
-  noport_b_html: '你的系统可能缺少驱动程序。请按照<a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/INSTALL_DRIVER_ESP32_S3.md">驱动安装指南</a>操作。',
+  noport_b_html: '你的系统可能缺少驱动程序。请按照<a href="https://github.com/TigerTag-Project/Tiger-Scale-V3/blob/main/docs/SERIAL-PORT.md">驱动安装指南</a>操作。',
 
   s3_title: "装完之后",
   a1_html: "秤会启动并询问 <b>WiFi</b>。在触摸屏上选择你的网络。",


### PR DESCRIPTION
Follow-up to #10, which is already merged. Three corrections, no change to what the guide teaches.

## Where the guide lives

It landed at the repository root as `INSTALL_DRIVER_ESP32_S3.md`, where no other user-facing guide lives — everything a user reads is under `docs/`. It moves to `docs/SERIAL-PORT.md`.

It was also reachable from exactly one place: the web installer. Not from the README documentation table, and not from `docs/TROUBLESHOOTING.md`, which is where somebody whose flasher shows no port actually looks first. Both now point at it. All nine language links in `web-installer/i18n.js` follow the move.

## The Windows step

It asked the reader to paste one line that downloads an executable and runs it with administrator rights:

```powershell
Invoke-WebRequest ... -OutFile .\idf-env.exe; .\idf-env.exe driver install --espressif
```

The domain is Espressif's own and the tool is legitimate, so this is not a security finding. But it is a gesture a project should not teach — the same muscle memory pasted from a less careful page is how people get compromised, and there is no signature or checksum check in the line. The guide now links Espressif's download page, shows the command to run once the tool is on disk, and says in one sentence why the extra click is worth it.

## Naming

The guide said "Tiger Scale v3"; the product is TigerScale V3 everywhere else.

## Testing

Docs and web-installer assets only, no firmware touched. `bash scripts/verify.sh` passes. Merging redeploys Pages via `pages.yml`, as #10 did.