### PR TITLE
Fix the Windows driver link and spell out every step for a beginner

### DIFF
--- a/docs/SERIAL-PORT.md
+++ b/docs/SERIAL-PORT.md
@@ -21,22 +21,29 @@ If it doesn't appear: swap the USB cable and try again.
 
 ## Windows — install the driver (if no COM port appears)
 
-If the flasher shows no port, the Espressif USB driver is missing. Install it
-from Espressif's own tooling page:
+If the flasher shows no port, the Espressif USB driver is missing. Here is how
+to install it, step by step:
 
-**[dl.espressif.com/dl/idf-installer](https://dl.espressif.com/dl/idf-installer/)**
+1. **Download the tool** — click this link, it downloads `idf-env.exe` straight
+   from Espressif's own server (by default it lands in your **Downloads**
+   folder):
+   **[https://dl.espressif.com/dl/idf-env/idf-env.exe](https://dl.espressif.com/dl/idf-env/idf-env.exe)**
+2. **Open PowerShell as administrator** — click the **Start** menu, type
+   `powershell`, right-click **Windows PowerShell** and choose **Run as
+   administrator**.
+3. **Copy this single line, paste it into PowerShell, then press Enter:**
 
-Download `idf-env` from there, then run it as administrator with:
+   ```powershell
+   cd $env:USERPROFILE\Downloads; .\idf-env.exe driver install --espressif
+   ```
 
-```powershell
-.\idf-env.exe driver install --espressif
-```
+   > Saved the file somewhere other than Downloads? Replace only
+   > `$env:USERPROFILE\Downloads` with that folder — for example
+   > `C:\Users\yourname\Desktop`. The rest of the line stays the same.
 
-Then:
-
-1. Wait for it to finish (a few seconds).
-2. **Unplug and plug the board back in.**
-3. Reopen the flasher: the port (e.g. `USB JTAG/serial debug unit (COM3)`) should now appear.
+4. Wait for it to finish (a few seconds).
+5. **Unplug and plug the board back in.**
+6. Reopen the flasher: the port (e.g. `USB JTAG/serial debug unit (COM3)`) should now appear.
 
 > Downloading the tool yourself, rather than pasting a one-line command that
 > fetches and runs an executable with administrator rights, means you can see


### PR DESCRIPTION
## What does this change?

Fixes two problems in the Windows section of `docs/SERIAL-PORT.md`:

1. **The download link was dead.** `dl.espressif.com/dl/idf-installer` returns a 404 (S3 "NoSuchKey") — it points at a page that doesn't exist. Replaced with the direct file link Espressif's own `espressif/idf-env` README still recommends today: `https://dl.espressif.com/dl/idf-env/idf-env.exe`. Shown with the full `https://` so copying the link text (instead of clicking it) still resolves as a secure URL rather than being interpreted as plain HTTP by the browser.
2. **The tutorial wasn't detailed enough for a Windows beginner.** `.\idf-env.exe driver install --espressif` silently assumes PowerShell is already open in whatever folder the file landed in — nothing said how to get there, so someone who opens PowerShell from the Start menu gets "the term '.\idf-env.exe' is not recognized." The steps now spell out opening PowerShell as administrator, then give one copy-pasteable line that changes into the Downloads folder and runs the tool from there, plus a one-line note for anyone who saved the file somewhere else.

## Why?

Both were found by walking through the guide as if seeing it for the first time. The dead link means step 1 fails immediately for every Windows reader; the missing "which folder" step means even someone who finds a working download link hits a confusing error on step 2. Together they make the Windows path currently unusable as written.

## How was it tested?

Docs only — no firmware code touched.
- Confirmed `dl.espressif.com/dl/idf-installer` 404s and that `https://dl.espressif.com/dl/idf-env/idf-env.exe` is still Espressif's own current recommended link (checked their GitHub README and release assets).
- Read through the rewritten steps end to end as a first-time Windows reader would, checking every "type this" / "click this" instruction is unambiguous about what changes and what stays fixed.

## Checklist

- [x] `bash scripts/check-codemap.sh` passes — N/A, `.ino` not touched
- [x] `bash scripts/check-i18n.sh` passes — N/A, this guide isn't part of the translated web-installer/firmware i18n sets
- [x] `bash scripts/update_toc.sh` run — N/A, no `// §N —` banner touched
- [x] `WORKLOG.md` updated — N/A, WORKLOG.md is maintainer-scoped, not touched by this fork PR
- [x] Comments I touched are still true of the code around them
- [x] Smallest diff that does the job — only the Windows section changed, macOS and Linux untouched