### PR TITLE
Warn upfront that TigerScale V3 isn't TigerPOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ place a spool carrying a TigerTag tag on the platform and it identifies the spoo
 weighs it, subtracts the empty spool's weight and reports how much filament is
 left. MIT licensed, built with PlatformIO.
 
+> [!WARNING]
+> **TigerScale V3 is different from [TigerPOD](https://github.com/TigerTag-Project/TigerPOD).** They don't offer the same features.
+
 ---
 
 ## What it does


### PR DESCRIPTION
TigerScale V3 and TigerPOD share the TigerTag name and ecosystem, but do different jobs — a filament scale versus a desktop NFC reader/writer. Easy to conflate before reading past the hero image, so this adds a native GitHub alert right after the intro paragraph saying so upfront.